### PR TITLE
[Docs] Improves setup instruction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ as well because `client.js` is your entry and every dependendcy will be resolved
 
 This repo is a POC and something we will build on. To try this out, clone this repository and then run
 
-```console
+```sh
 # Init Preact Git Sumodule
 git submodule init
 git submodule update
@@ -197,6 +197,13 @@ yarn
 
 # Build Preact
 cd packages/preact
+yarn build
+
+# Build the pool-attendant-preact package
+# └─ cd to the pool-attendant-preact dir
+cd ...
+cd packages/pool-attendant-preact
+# └─ build the package
 yarn build
 
 # cd to the app dir


### PR DESCRIPTION
Hi,

I just checked out the example app and followed your setup instructions in the readme.
After running the last last step of the instruction I noticed that the task refused to start because the `dist` dir was not present on the `pool-attendant-preact`-package.

So running the rollup-task in the `pool-attendant-preact`-package before running the app is a necessary step.

Put together this quick PR to improve the readme for less experienced users, so feel free to accept it 😊